### PR TITLE
Insomnia.cpp error on non default boards.

### DIFF
--- a/Insomnia.cpp
+++ b/Insomnia.cpp
@@ -12,7 +12,7 @@
 #include "Arduino.h"
 #include "Insomnia.h"
 
-Insomnia::Insomnia(unsigned long timeoutTime = 5000) {
+Insomnia::Insomnia(unsigned long timeoutTime) {
   _timeoutTime = timeoutTime;
   _previousTime = millis();
 }


### PR DESCRIPTION
The default parameter should only be specified in the function declaration, i.e. in the header file.